### PR TITLE
Added try/catch to searchPathInJson JSON.parse & Fixed a bug when editor is empty

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -128,8 +128,13 @@ function showQuickPick(path, filesFound) {
 function searchPathInJson(pathArray, json) {
   return vscode.workspace.fs.readFile(json).then((content) => {
     const jsonString = Buffer.from(content).toString();
-    const jsonObject = JSON.parse(jsonString);
-    return deepFind(pathArray, jsonObject, true) && { json, jsonString };
+    try {
+      const jsonObject = JSON.parse(jsonString);
+      return deepFind(pathArray, jsonObject, true) && { json, jsonString };
+    } catch (e) {
+      console.error(`Parse error in ${json.path}`, e);
+      return;
+    }
   });
 }
 

--- a/extension.js
+++ b/extension.js
@@ -171,13 +171,16 @@ function removePrefixAndSuffix(value) {
 }
 
 function getValue() {
-  const value = vscode.window.activeTextEditor.document.getText(
-    vscode.window.activeTextEditor.selection
-  );
-  if (!value) {
-    return;
+  if (vscode.window.activeTextEditor) {
+    const value = vscode.window.activeTextEditor.document.getText(
+      vscode.window.activeTextEditor.selection
+    );
+    if (!value) {
+      return;
+    }
+    return removePrefixAndSuffix(value);
   }
-  return removePrefixAndSuffix(value);
+  return;
 }
 
 function showInput(value) {


### PR DESCRIPTION
Hi, thank you for the extension!
I was trying to use it in my current project but faced a couple of issues.

### Issue 1
The input box gets stuck after I inserted the JSON path, without any logs/errors.
It took me a while to learn to debug vs code extensions 😅  But I found what was causing the issue.
Some of the JSON files in my project have comments, which makes it not possible to parse. And unfortunately, I cannot remove these comments, because they are actually valid and will be removed during the build.

### Solution
I think wrapping parsing in `try/catch` block won't do any harm and this might actually prevent the extension from being stuck if some JSON files are not parsable for any reason.
I've also added `console.error`.

### Issue 2
Getting an error, when running the `search json path` command, while there are no files open in "vs editor".

![Screenshot 2021-12-03 at 17 07 49](https://user-images.githubusercontent.com/28235413/144634467-b2341b7f-82f8-4e3a-9392-d8a1afe8c9f7.png)

### Solution
The problem was that `vscode.window.activeTextEditor` is undefined if nothing is open. Just added a safety check.
