### PR TITLE
update config format (#2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,23 @@
           "description": "enable addon"
         },
         "search-json-path.prefixAndSuffix": {
-          "type": "array",
-          "items": {"type": "string"},
-          "default": ["'","\""],
+          "type": [
+            "string",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "string",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "default": [
+            "'",
+            "\""
+          ],
           "description": "allowable delimiters for JSON keys"
         },
         "search-json-path.codeLenses.enable": {

--- a/package.json
+++ b/package.json
@@ -41,18 +41,24 @@
       ]
     },
     "configuration": {
-      "title": "Search JSON Path configuration",
+      "title": "Search JSON Path",
       "type": "object",
       "properties": {
-        "search-json-path": {
-          "enable": true,
-          "prefixAndSuffix": [
-            "'",
-            "\""
-          ],
-          "codeLenses": {
-            "enable": false
-          }
+        "search-json-path.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "enable addon"
+        },
+        "search-json-path.prefixAndSuffix": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": ["'","\""],
+          "description": "allowable delimiters for JSON keys"
+        },
+        "search-json-path.codeLenses.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "enable JSON search path code lens"
         }
       }
     }


### PR DESCRIPTION
Resolves #2 


Update the configuration contribution point in package.json. This prevents an error in activate() when relying on default config values.

This PR was made based on the advice of [this article](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration) and the format for lists was gleaned from [an MIT-licensed extension's package.json](https://github.com/microsoft/vscode-cmake-tools/blob/main/package.json).